### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Haversine
+version=0.0.0
+author=Matheau Goonan
+maintainer=Matheau Goonan
+sentence=Use the haversine equation to determine the bearing and distance between two GPS points. 
+paragraph=
+category=Data Processing
+url=https://github.com/matgoonan/Haversine
+architectures=*
+includes=Haversine.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the `src` subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata